### PR TITLE
테이블 초기값 중복 해결

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,1 +1,1 @@
-INSERT INTO users (nickname, user_comment, email, password, created_date, category) VALUES ('김혜승', 'hyeseung', 's2224@e-mirim.hs.kr', 'hyeseung1!', '2023-10-20 10:11:20', 1);
+REPLACE INTO users (nickname, user_comment, email, password, created_date, category) VALUES ('김혜승', 'hyeseung', 's2224@e-mirim.hs.kr', 'hyeseung1!', '2023-10-20 10:11:20', 1);


### PR DESCRIPTION
## - 일단 `DDL_AUTO`를 create -> update로 변경

create를 하면 entity drop후 재생성 되는지라 서버 실행할 때마다 데이터가 날아갑니다.
그래서 update로 바꾸었습니다.

또한 초기값 sql의 INSERT구문을 REPLACE로 바꾸었습니다.
update로 바꾼후 서버를 실행하니까 PK중복 에러가 나서 그렇습니다.